### PR TITLE
Add v1 in API endpoint

### DIFF
--- a/src/main/java/it/infn/ba/indigo/chronos/client/Chronos.java
+++ b/src/main/java/it/infn/ba/indigo/chronos/client/Chronos.java
@@ -11,27 +11,27 @@ import it.infn.ba.indigo.chronos.client.utils.ChronosException;
 
 public interface Chronos {
 
-  @RequestLine("GET /scheduler/jobs")
+  @RequestLine("GET /v1/scheduler/jobs")
   Collection<Job> getJobs();
 
-  @RequestLine("GET /scheduler/jobs/search?name={name}")
+  @RequestLine("GET /v1/scheduler/jobs/search?name={name}")
   Collection<Job> getJob(@Param("name") String name);
 
   @Headers("Content-Type: application/json")
-  @RequestLine("POST /scheduler/iso8601")
+  @RequestLine("POST /v1/scheduler/iso8601")
   void createJob(Job job) throws ChronosException;
 
   @Headers("Content-Type: application/json")
-  @RequestLine("POST /scheduler/dependency")
+  @RequestLine("POST /v1/scheduler/dependency")
   void createDependentJob(Job job) throws ChronosException;
 
-  @RequestLine("PUT /scheduler/job/{name}")
+  @RequestLine("PUT /v1/scheduler/job/{name}")
   void startJob(@Param("name") String name) throws ChronosException;
 
-  @RequestLine("DELETE /scheduler/job/{name}")
+  @RequestLine("DELETE /v1/scheduler/job/{name}")
   void deleteJob(@Param("name") String name) throws ChronosException;
 
-  @RequestLine("DELETE /scheduler/task/kill/{name}")
+  @RequestLine("DELETE /v1/scheduler/task/kill/{name}")
   void deleteJobTasks(@Param("name") String name) throws ChronosException;
 
 }


### PR DESCRIPTION
Since v3.0.0 API paths have changed (they are now prefixed with /v1)
See https://github.com/mesos/chronos/releases/tag/v3.0.0